### PR TITLE
feat: allow sharp strategy option in resize

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,9 @@ type ImageFit =
   | "left bottom"
   | "left"
   | "left top"
-  | "center";
+  | "center"
+  | "entropy" // only in combination with ImageFit cover
+  | "attention"; // only in combination with ImageFit cover;
 ```
 
 ### Example config

--- a/server/config/schema.ts
+++ b/server/config/schema.ts
@@ -37,6 +37,8 @@ const positions = [
   "left",
   "left top",
   "center",
+  "entropy",
+  "attention",
 ];
 
 const configSchema = object({

--- a/server/models/config.ts
+++ b/server/models/config.ts
@@ -88,4 +88,6 @@ export type ImagePosition =
   | "left bottom"
   | "left"
   | "left top"
-  | "center";
+  | "center"
+  | "entropy"
+  | "attention";


### PR DESCRIPTION
To let the image resize, focus on a specific point or when people are included at the faces, sharp provides strategy-based approach resizes.

This option can be an improvement of image resizes and provide further optimizations to the user.