### PR TITLE
fix: typing and add additional docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ module.exports = (plugin) => {
 
 ### 3. Add config options
 
-Configure the plugin in the `.config/plugins.js/ts` file of your Strapi project.
+Configure the plugin in the `.config/plugins.(js/ts)` file of your Strapi project.
 
 ## Config options
 
@@ -136,6 +136,8 @@ type ImageFit =
 
 ### Example config
 
+The following config would be a good starting point for your project.
+
 ```typescript
 // ./config/plugins.ts
 
@@ -174,6 +176,25 @@ export default ({ env }) => ({
     },
   },
   // ...
+});
+```
+
+If you want type safety, you can extend the configuration with our config typing.
+
+With that approach, you will get the possibility for property IntelliSense and static string type values.
+
+```typescript
+import { Config as ImageOptimizerConfig } from "strapi-plugin-image-optimizer/dist/server/models/config";
+
+// ...
+export default ({ env }) => ({
+  // ...
+  "image-optimizer": {
+    // ...
+    config: {
+      // ...
+    } satisfies ImageOptimizerConfig,
+  },
 });
 ```
 

--- a/server/models/config.ts
+++ b/server/models/config.ts
@@ -18,7 +18,7 @@ export interface Config {
   /**
    * The image sizes to generate. Default is [].
    */
-  sizes?: ImageSize[];
+  sizes: ImageSize[];
   /**
    * The quality of the generated images. Default is 80.
    */


### PR DESCRIPTION
Since in the docs it is stated that 

| `sizes`<sup>\*</sup>    | [`ImageSize`](#object-imagesize)`[]`     | (required) - Specify the sizes to which the uploaded image should be 

it should be reflected in the type definition.

Also added information about type safety in plugins.ts