### PR TITLE
Fix: Update intermediate image hash

### DIFF
--- a/server/services/image-optimizer-service.ts
+++ b/server/services/image-optimizer-service.ts
@@ -99,7 +99,7 @@ async function resizeFileTo(
     sourceFile
   );
 
-  const imageHash = `${sizeName}_${sourceFile.hash}`;
+  const imageHash = `${sizeName}_${format}_${sourceFile.hash}`;
   const filePath = join(sourceFile.tmpWorkingDirectory, imageHash);
   const newImageStream = sourceFile.getStream().pipe(sharpInstance);
   await writeStreamToFile(newImageStream, filePath);


### PR DESCRIPTION
This PR fixes #33, by including the format of the output image in the  intermediate image-file hash.
