### PR TITLE
Feat add folder support

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,9 @@
   "peerDependencies": {
     "@strapi/core": "*",
     "@strapi/strapi": "^4.20.5",
-    "@strapi/utils": "^4.20.5",
+    "@strapi/utils": "^4.20.5"
+  },
+  "dependencies": {
     "yup": "^1.4.0"
   },
   "scripts": {

--- a/server/models/file.ts
+++ b/server/models/file.ts
@@ -6,6 +6,8 @@ export interface File {
   mime: string;
   path?: string;
   ext: string;
+  folder?: string;
+  folderPath?: string;
   width?: number;
   height?: number;
   size?: number;

--- a/server/services/image-optimizer-service.ts
+++ b/server/services/image-optimizer-service.ts
@@ -113,6 +113,8 @@ async function resizeFileTo(
     ext: getFileExtension(sourceFile, format),
     mime: getFileMimeType(sourceFile, format),
     path: sourceFile.path,
+    folder: sourceFile.folder,
+    folderPath: sourceFile.folderPath,
     width: metadata.width,
     height: metadata.height,
     size: metadata.size && fileUtils.bytesToKbytes(metadata.size),


### PR DESCRIPTION
If we use folders in starpa thumbnails also should be stored in folders.
For example:
Now it works like that:
MediaLibrarry/news/image-1.png => MediaLibrarry/thumbnail-image-1.avif

In that PR we change it to:
MediaLibrarry/news/image-1.png => MediaLibrarry/news/thumbnail-image-1.avif